### PR TITLE
zobrazovat spravne cislo ulohy v upload.pl

### DIFF
--- a/upload.pl
+++ b/upload.pl
@@ -53,7 +53,7 @@ if ( $Mode eq "config" ) {
     }
     AppendConfig ($ConfigName);
 } else {
-    unshift(@_,$Mode);
+    unshift(@ARGV, $Mode);
 }
 
 


### PR DESCRIPTION
Pri spracovani dlazcis sa vypisuje stav cez statusMessage() a prve vypisovane cislo je poradove cislo ulohy $progressJobs.
Funguje to vo vacsine stavovych sprav (prvy riadok prikladu), len pri "upload" vypisuje stale #0 (dalsie riadky).

[#2 100% freemap] Finished 2267,1403 for layer freemap
[#0   0% uploadZ] 0 zip files to upload...
[#0   0%  upload] Searching for tiles in /freemap-disk-10/...
[#0   0%  upload] zip is larger than 2 MB, retrying as split tileset.
[#0   0%  upload] 341 tiles to process...

Navrhovana zmena to u mna opravuje (perl 5.26.2) a vypisuje spravne cislo (napr. #2) aj pri "upload".