### PR TITLE
Povolit Inkscape >= 1.0

### DIFF
--- a/tahconfig.pm
+++ b/tahconfig.pm
@@ -117,8 +117,16 @@ sub CheckConfig {
         die("Can't find inkscape (using \"$Config{Inkscape}\")\n");
     }
 
-    if ( $2 < 45.0 ) {
-        die("not supported version of Inkscape\@home\n");
+    if ( ($1 == 0) ) {
+        if ($2 < 45.0) {
+            die("not supported version of Inkscape\@home\n");
+        }
+        else {
+            $EnvironmentInfo{Inkscape1} = 0;
+        }
+    }
+    else {
+        $EnvironmentInfo{Inkscape1} = 1;
     }
     print "- Inkscape version $1.$2\n";
 


### PR DESCRIPTION
Kontrola overovala len minor verziu Inkscape, co fungovalo kym hlavna verzia bola 0.

Znacim si ze mame Inkscape >= 1 do premennej $EnvironmentInfo{Inkscape1} lebo to este budeme potrebovat.

Opravuje cast issue #95.

(Inak netusim co znamena to @home za nazvom Inkscape, dost ma to miatlo kym som to ladil.)