### PR TITLE
Podpora Inkscape >= 1.0 v tilesGen.pl

### DIFF
--- a/tilesGen.pl
+++ b/tilesGen.pl
@@ -1241,13 +1241,20 @@ sub svg2png {
         );
     }
     else {
-        $Cmd = sprintf( "%s %s -w %d -h %d --export-area=%f:%f:%f:%f --export-png=\"%s\" \"%s%s\" > %s",
+        my $exportOpts;
+        if ( $EnvironmentInfo{Inkscape1} == 1 ) {
+            $exportOpts = sprintf( "--export-type=png --export-filename=\"%s.png\"", $TempFile );
+        }
+        else {
+            $exportOpts = sprintf( "--export-png=\"%s\"", $TempFile );
+        }
+        $Cmd = sprintf( "%s %s -w %d -h %d --export-area=%f:%f:%f:%f %s \"%s%s\" > %s",
             $Config{Niceness},
             $Config{Inkscape},
             $Width,
             $Height,
             $X1, $Y1, $X2, $Y2,
-            $TempFile,
+            $exportOpts,
             $Config{WorkingDirectory},
             "output-$PID-z$Zoom.svg",
             $stdOut
@@ -1280,7 +1287,7 @@ sub svg2png {
     }
 
     #-------------------------------------
-    if ( $Config{UseBatik} == 1 ) {
+    if ( ( $Config{UseBatik} == 1 ) || ( $EnvironmentInfo{Inkscape1} == 1 ) ) {
         rename( $TempFile . ".png", $TempFile );
     }
 


### PR DESCRIPTION
Inkscape 1.0 ma iny argument pre export suboru (aj ked zda sa zatial --export-png potichu akceptuje) a vzdy vytvori subor s koncovkou .png bez ohladu na zadany nazov. Takze ho premenujeme az potom ako pri Batiku.

Riesi cast issue #95.